### PR TITLE
fixed: filepath has no value if userfilepath exist.

### DIFF
--- a/scripts/supermerger.py
+++ b/scripts/supermerger.py
@@ -36,6 +36,7 @@ def on_ui_tabs():
         try:
             with open(userfilepath) as f:
                 weights_presets = f.read()
+                filepath = userfilepath
         except OSError as e:
                 pass
     else:


### PR DESCRIPTION
If "userfilepath" exist, the "filepath" will be null.
and
`def openeditors():
            subprocess.Popen(['start', filepath], shell=True)`
will cause Error.