### PR TITLE
Fix: checking scikit-learn

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,6 +1,6 @@
 import launch
 
-if not launch.is_installed("scikit"):
+if not launch.is_installed("sklearn"):
     launch.run_pip("install scikit-learn", "scikit-learn")
 
 if not launch.is_installed("diffusers"):


### PR DESCRIPTION
`sklearn` is the name to import `scikit-learn`, not `scikit` or `scikit-learn`
For now the install.py will try install `scikit-learn` no matter if there already is `scikit-learn`