### PR TITLE
Fixes for recent Diffusers version LORA handling

### DIFF
--- a/scripts/mergers/model_util.py
+++ b/scripts/mergers/model_util.py
@@ -725,9 +725,6 @@ def filenamecutter(name,model_a = False):
 def load_models_from_stable_diffusion_checkpoint(v2, ckpt_path, dtype=None):
   import diffusers
   print("diffusers version : ",diffusers.__version__)
-  version = diffusers.__version__.split(".")[1]
-  if int(version) > 14:
-    return None,None,None, f"ERROR: version of diffusers is different, use version 0.10.2 - 0.14.0, your version is {diffusers.__version__}"
 
   state_dict = load_checkpoint_with_text_encoder_conversion(ckpt_path)
   if dtype is not None:

--- a/scripts/mergers/pluslora.py
+++ b/scripts/mergers/pluslora.py
@@ -1091,6 +1091,7 @@ class LoRANetwork(torch.nn.Module):
         # create module instances
         def create_modules(prefix, root_module: torch.nn.Module, target_replace_modules) -> List[LoRAModule]:
             loras = []
+            processed = {}
             for name, module in root_module.named_modules():
                 if module.__class__.__name__ in target_replace_modules:
                     # TODO get block index here
@@ -1101,6 +1102,9 @@ class LoRANetwork(torch.nn.Module):
                         if is_linear or is_conv2d:
                             lora_name = prefix + "." + name + "." + child_name
                             lora_name = lora_name.replace(".", "_")
+                            if lora_name in processed:
+                                continue
+                            processed[lora_name] = True
 
                             if modules_dim is not None:
                                 if lora_name not in modules_dim:


### PR DESCRIPTION
Newer Diffusers versions were triggering a bug in the LORA code that caused parameters to be processed multiple times, resulting in duplicate keys. This fixes that bug and removes the version check.

This is necessary to support the version of Diffusers automatically installed by the Dreambooth extension on startup (currently 0.16.1).