### PR TITLE
Preserve alternating word syntax.

### DIFF
--- a/scripts/mergers/xyplot.py
+++ b/scripts/mergers/xyplot.py
@@ -5,6 +5,7 @@ import numpy as np
 import os
 import copy
 import csv
+import re
 from PIL import Image
 from modules import images
 from modules.shared import opts
@@ -47,6 +48,10 @@ def numanager(startmode,xtype,xmen,ytype,ymen,ztype,zmen,esettings,
     global numadepth
     grids = []
     sep = "|"
+    if sep == "|":
+        sepre = re.compile(rf'{re.escape(sep)}(?![^\[\]]*\])')
+    else:
+        sepre = re.compile(rf'{re.escape(sep)}')
 
     if RAND in startmode:
         if "off" in lmode:return "Random mode is off",*[None]*5
@@ -68,9 +73,9 @@ def numanager(startmode,xtype,xmen,ytype,ymen,ztype,zmen,esettings,
     print(xtype,xmen,ytype,ymen,weights_a,weights_b)
 
     if RAND not in startmode:
-        if sep in xmen: allsets = separator(allsets,1,sep,xmen,seed,startmode)
-        if sep in ymen: allsets = separator(allsets,3,sep,ymen,seed,startmode)
-        if sep in zmen: allsets = separator(allsets,5,sep,zmen,seed,startmode)
+        if sepre.search(xmen): allsets = separator(allsets,1,sepre,xmen,seed,startmode)
+        if sepre.search(ymen): allsets = separator(allsets,3,sepre,ymen,seed,startmode)
+        if sepre.search(zmen): allsets = separator(allsets,5,sepre,zmen,seed,startmode)
 
     if "reserve" in startmode : return numaker(allsets)
 
@@ -108,9 +113,9 @@ def numanager(startmode,xtype,xmen,ytype,ymen,ztype,zmen,esettings,
 
     return result,currentmodel,grids,a,b,c
 
-def separator(allsets,index,sep,men,seed,startmode):
+def separator(allsets,index,sepre,men,seed,startmode):
     if seed =="-1": allsets[30] = str(random.randrange(4294967294))
-    mens = men.split(sep)
+    mens = re.split(sepre, men)
     if "reserve" not in startmode:
         allsets[index] = mens[0]
         for men in mens[1:]:


### PR DESCRIPTION
Splitting on the pipe character breaks the alternating word syntax in prompts.  This change will prevent splitting on pipe characters that are between square brackets.