### PR TITLE
Fallback for empty model_c in "trainDifference" check

### DIFF
--- a/scripts/mergers/mergers.py
+++ b/scripts/mergers/mergers.py
@@ -177,7 +177,11 @@ def smerge(weights_a,weights_b,model_a,model_b,model_c,base_alpha,base_beta,mode
     if calcmode == "trainDifference" and "Add" not in mode:
         print(f"{bcolors.WARNING}Mode changed to add difference{bcolors.ENDC}")
         mode = "Add"
-
+        if model_c == "":
+            #fallback to avoid crash
+            model_c = model_a
+            print(f"{bcolors.WARNING}Substituting empty model_c with model_a{bcolors.ENDC}")
+            
     result_is_inpainting_model = False
     result_is_instruct_pix2pix_model = False
 

--- a/scripts/mergers/mergers.py
+++ b/scripts/mergers/mergers.py
@@ -174,7 +174,7 @@ def smerge(weights_a,weights_b,model_a,model_b,model_c,base_alpha,base_beta,mode
 
     caster(mergedmodel,False)
 
-    if calcmode == calcmode == "trainDifference" and "Add" not in mode:
+    if calcmode == "trainDifference" and "Add" not in mode:
         print(f"{bcolors.WARNING}Mode changed to add difference{bcolors.ENDC}")
         mode = "Add"
 


### PR DESCRIPTION
`    if calcmode == calcmode == "trainDifference" and "Add" not in mode:
        print(f"{bcolors.WARNING}Mode changed to add difference{bcolors.ENDC}")
        mode = "Add"
`
Leads to a crash further down the line, because model_c is empty, which leads to a empty current model being returned later, stopping a sequential generation, if no model_c is selected in the ui.

I stumbled over this when I simply ran x/y sequential merge for all calcmodes while having the weight sum mode selected.

Hiding trainDifference, if model_c is empty, would be nicer, but this is an easier fix for me, as you also would have to hide it from the sequence helpers that pop up when "calcmode" is selected as "x" or "y" axis.