### PR TITLE
support saving current merged model

### DIFF
--- a/scripts/mergers/mergers.py
+++ b/scripts/mergers/mergers.py
@@ -35,7 +35,7 @@ from scripts.mergers.bcolors import bcolors
 import collections
 
 try:
-    ui_version = int(launch.git_tag().replace("v","").replace(".",""))
+    ui_version = int(launch.git_tag().split("-",1)[0].replace("v","").replace(".",""))
 except:
     ui_version = 100
 

--- a/scripts/mergers/mergers.py
+++ b/scripts/mergers/mergers.py
@@ -134,7 +134,7 @@ def smergegen(weights_a,weights_b,model_a,model_b,model_c,base_alpha,base_beta,m
 
     save = True if SAVEMODES[0] in save_sets else False
 
-    result = savemodel(theta_0,currentmodel,custom_name,save_sets,model_a,metadata) if save else "Merged model loaded:"+currentmodel
+    result = savemodel(theta_0,currentmodel,custom_name,save_sets,metadata) if save else "Merged model loaded:"+currentmodel
 
     sd_models.model_data.__init__()
     load_model(checkpoint_info, already_loaded_state_dict=theta_0)
@@ -168,6 +168,7 @@ def fake_checkpoint_info(checkpoint_info,metadata,currentmodel):
     checkpoint_info.name = checkpoint_info.name_for_extra + ".safetensors"
     checkpoint_info.model_name = checkpoint_info.name_for_extra.replace("/", "_").replace("\\", "_")
     checkpoint_info.title = f"{checkpoint_info.name} [{sha256[0:10]}]"
+    checkpoint_info.metadata = metadata
 
         # force to set a new sha256 hash
     if c_cache is not None: 
@@ -233,7 +234,6 @@ def smerge(weights_a,weights_b,model_a,model_b,model_c,base_alpha,base_beta,mode
     # mode select booleans
     save = True if SAVEMODES[0] in save_sets else False
     usebeta = MODES[2] in mode or MODES[3] in mode or "tensor" in calcmode
-    save_metadata = "save metadata" in save_sets
     metadata = {"format": "pt"}
 
     if not useblocks:
@@ -696,7 +696,7 @@ def smerge(weights_a,weights_b,model_a,model_b,model_c,base_alpha,base_beta,mode
 
     caster(mergedmodel,False)
 
-    if save_metadata:
+    if True: # always set metadata. savemodel() will check save_sets later
         merge_recipe = {
             "type": "sd-webui-supermerger",
             "weights_alpha": weights_a if useblocks else None,

--- a/scripts/mergers/model_util.py
+++ b/scripts/mergers/model_util.py
@@ -667,6 +667,14 @@ def load_checkpoint_with_text_encoder_conversion(ckpt_path):
 
   return state_dict
 
+def prune_model(model, isxl=False):
+    keys = list(model.keys())
+    base_prefix = "conditioner." if isxl else "cond_stage_model."
+    for k in keys:
+        if "diffusion_model." not in k and "first_stage_model." not in k and base_prefix not in k:
+            model.pop(k, None)
+    return model
+
 def to_half(sd):
     for key in sd.keys():
         if 'model' in key and sd[key].dtype == torch.float:
@@ -752,6 +760,8 @@ def savemodel(state_dict,currentmodel,fname,savesets,metadata={}):
 
     if "fp16" in savesets:
         state_dict = to_half(state_dict)
+    if "prune" in savesets:
+        state_dict = prune_model(state_dict, isxl)
 
     try:
       if ext == ".safetensors":

--- a/scripts/mergers/pluslora.py
+++ b/scripts/mergers/pluslora.py
@@ -629,7 +629,7 @@ def pluslora(lnames,loraratios,settings,output,model,precision):
     #usemodelgen(theta_0,model)
     settings.append(precision)
     settings.append("safetensors")
-    result = savemodel(theta_0,dname,output,settings,model)
+    result = savemodel(theta_0,dname,output,settings)
     del theta_0
     gc.collect()
     return result

--- a/scripts/mergers/xyplot.py
+++ b/scripts/mergers/xyplot.py
@@ -407,7 +407,7 @@ def sgenxyplot(xtype,xmen,ytype,ymen,ztype,zmen,esettings,
                     load_model(checkpoint_info, already_loaded_state_dict=theta_0)
 
                 if "save model" in esettings:
-                    savemodel(theta_0,currentmodel,custom_name,save_sets,model_a,metadata) 
+                    savemodel(theta_0,currentmodel,custom_name,save_sets,metadata) 
                 theta_0 = None
                 del theta_0
 

--- a/scripts/supermerger.py
+++ b/scripts/supermerger.py
@@ -86,7 +86,7 @@ def on_ui_tabs():
                     with gr.Accordion("Save Settings", open=False):
                         with gr.Row():
                             with gr.Column(scale = 3):
-                                save_sets = gr.CheckboxGroup(["save model", "overwrite","safetensors","fp16","save metadata"], value=["safetensors"], show_label=False, label="save settings")
+                                save_sets = gr.CheckboxGroup(["save model", "overwrite","safetensors","fp16","save metadata","prune"], value=["safetensors"], show_label=False, label="save settings")
                             with gr.Column(min_width = 50, scale = 1):
                                 components.id_sets = gr.CheckboxGroup(["image", "PNG info"], label="save merged model ID to")
 

--- a/scripts/supermerger.py
+++ b/scripts/supermerger.py
@@ -101,7 +101,7 @@ def on_ui_tabs():
                                     create_refresh_button(bake_in_vae, sd_vae.refresh_vae_list, lambda: {"choices": ["None"] + list(sd_vae.vae_dict)}, "modelmerger_refresh_bake_in_vae")
 
                         with gr.Row():
-                            savecurrent = gr.Button(elem_id="savecurrent", elem_classes=["compact_button"], value="Save current merge")
+                            savecurrent = gr.Button(elem_id="savecurrent", elem_classes=["compact_button"], value="Save current merge(fp16 only)")
 
                     with gr.Row():
                         components.merge = gr.Button(elem_id="model_merger_merge", elem_classes=["compact_button"], value="Merge!",variant='primary')

--- a/scripts/supermerger.py
+++ b/scripts/supermerger.py
@@ -26,7 +26,7 @@ import csv
 import scripts.mergers.pluslora as pluslora
 from scripts.mergers.mergers import (TYPESEG, freezemtime, rwmergelog, blockfromkey, clearcache, getcachelist)
 from scripts.mergers.xyplot import freezetime, nulister
-from scripts.mergers.model_util import filenamecutter
+from scripts.mergers.model_util import filenamecutter, savemodel
 
 path_root = basedir()
 
@@ -99,6 +99,9 @@ def on_ui_tabs():
                                 with gr.Row():
                                     bake_in_vae = gr.Dropdown(choices=["None"] + list(sd_vae.vae_dict), value="None", label="Bake in VAE", elem_id="modelmerger_bake_in_vae")
                                     create_refresh_button(bake_in_vae, sd_vae.refresh_vae_list, lambda: {"choices": ["None"] + list(sd_vae.vae_dict)}, "modelmerger_refresh_bake_in_vae")
+
+                        with gr.Row():
+                            savecurrent = gr.Button(elem_id="savecurrent", elem_classes=["compact_button"], value="Save current merge")
 
                     with gr.Row():
                         components.merge = gr.Button(elem_id="model_merger_merge", elem_classes=["compact_button"], value="Merge!",variant='primary')
@@ -449,6 +452,10 @@ def on_ui_tabs():
         mode.change(fn=lambda mode: [gr.update(info=mode_info[mode]), gr.update(interactive=True if mode in ["Triple sum", "sum Twice"] else False)], inputs=[mode], outputs=[mode, base_beta], show_progress=False)
         useblocks.change(fn=lambda mbw: gr.update(visible=False if mbw else True), inputs=[useblocks], outputs=[alpha_group])
 
+        def save_current_merge(custom_name, save_settings):
+            msg = savemodel(None,None,custom_name,save_settings)
+            return gr.update(value=msg)
+
         def addblockweights(val, blockopt, *blocks):
             if val == "none":
                 val = 0
@@ -550,6 +557,8 @@ def on_ui_tabs():
                 value = float(opt)
 
             return gr.update(value = value)
+
+        savecurrent.click(fn=save_current_merge, inputs=[custom_name, save_sets], outputs=[components.submit_result])
 
         resetopt.change(fn=resetvalopt,inputs=[resetopt],outputs=[resetval])
         resetweight.click(fn=resetblockweights,inputs=[resetval,resetblockopt],outputs=menbers)


### PR DESCRIPTION
 - [x] support saving the current merged model
 - [x] fix `ui_version` for dev
 - [x] support pruning

Support for merging without saving models is very convenient and often used.
On the other hand, it's a bit inconvenient to use a model without saving it when you change your mind and want to save it then you have to try to merge it again. this fix supports saving the current already merged model.

![image](https://github.com/hako-mikan/sd-webui-supermerger/assets/232347/ebf88205-3a92-4493-9fb2-23ee945219e3)
