### PR TITLE
Weight sum using torch.lerp()

### DIFF
--- a/scripts/mergers/mergers.py
+++ b/scripts/mergers/mergers.py
@@ -498,7 +498,10 @@ def smerge(weights_a,weights_b,model_a,model_b,model_c,base_alpha,base_beta,mode
                     theta_0_a = theta_1[key]
                 elif current_alpha !=0:
                     caster(f"{num}, {block}, {key}, {model_a}*{1-current_alpha}+{model_b}*{current_alpha}",hear)
-                    theta_0_a = (1 - current_alpha) * theta_0_a + current_alpha * theta_1[key]
+                    if "lerp" in mode:
+                        theta_0_a = torch.lerp(theta_0_a.to(torch.float32), theta_1[key].to(torch.float32), current_alpha).to(theta_0_a.dtype)
+                    else:
+                        theta_0_a = (1 - current_alpha) * theta_0_a + current_alpha * theta_1[key]
 
             if a != b and a[0:1] + a[2:] == b[0:1] + b[2:]:
                 theta_0[key][:, 0:4, :, :] = theta_0_a
@@ -861,6 +864,7 @@ def rwmergelog(mergedname = "",settings= [],id = 0):
     # for compatible
     mode_info = {
         "Weight sum": "Weight sum:A*(1-alpha)+B*alpha",
+        "Weight sum(lerp)": "Weight sum:A*(1-alpha)+B*alpha",
         "Add difference": "Add difference:A+(B-C)*alpha",
         "Triple sum": "Triple sum:A*(1-alpha-beta)+B*alpha+C*beta",
         "sum Twice": "sum Twice:(A*(1-alpha)+B*alpha)*(1-beta)+C*beta",

--- a/scripts/supermerger.py
+++ b/scripts/supermerger.py
@@ -83,7 +83,7 @@ def on_ui_tabs():
                         model_c = gr.Dropdown(sd_models.checkpoint_tiles(),elem_id="model_converter_model_name",label="Model C",interactive=True)
                         create_refresh_button(model_c, sd_models.list_models,lambda: {"choices": sd_models.checkpoint_tiles()},"refresh_checkpoint_Z")
 
-                    mode = gr.Radio(label = "Merge Mode",choices = ["Weight sum", "Add difference", "Triple sum", "sum Twice"], value="Weight sum", info="A*(1-alpha)+B*alpha") 
+                    mode = gr.Radio(label = "Merge Mode",choices = ["Weight sum", "Weight sum(lerp)", "Add difference", "Triple sum", "sum Twice"], value="Weight sum", info="A*(1-alpha)+B*alpha")
                     calcmode = gr.Radio(label = "Calculation Mode",choices = ["normal", "cosineA", "cosineB","trainDifference","smoothAdd","smoothAdd MT","tensor","tensor2","self"], value = "normal") 
                     with gr.Row(variant="compact"):
                         with gr.Column(scale = 1):
@@ -494,6 +494,7 @@ def on_ui_tabs():
 
         mode_info = {
             "Weight sum": "A*(1-alpha)+B*alpha",
+            "Weight sum(lerp)": "A*(1-alpha)+B*alpha",
             "Add difference": "A+(B-C)*alpha",
             "Triple sum": "A*(1-alpha-beta)+B*alpha+C*beta",
             "sum Twice": "(A*(1-alpha)+B*alpha)*(1-beta)+C*beta"


### PR DESCRIPTION
![image](https://github.com/hako-mikan/sd-webui-supermerger/assets/232347/9d8e7f13-aea7-44c6-8da9-ea589d919f1c)

`Weight sum(lerp)` added. same result but 2x~3x faster than normal `Weight sum`

![image](https://github.com/hako-mikan/sd-webui-supermerger/assets/232347/2b34e2ac-7571-4eca-991d-e1124ec78f52)
~~~
  model A       : Basil_mix_fixed
  model B       : Anything_v3Fixed-prunedFp16
  model C       : Basil_mix_fixed
  alpha,beta    : (0.5, 0.25)
  weights_alpha :
  weights_beta  :
  mode          : Weight sum(lerp)
  MBW           : False
  CalcMode      : normal
  Elemental     :
  Weights Seed  : 4216254361.0
  Adjust        :
Loading weights [Anything_v3Fixed-prunedFp16] from file
Loading weights [Basil_mix_fixed] from file
Stage 1/2: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1131/1131 [00:06<00:00, 164.94it/s]
Stage 2/2: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1131/1131 [00:00<?, ?it/s]
Saving...
Done!
Creating model from config: F:\webui\webui\stable-diffusion-webui\configs\v1-inference.yaml
Loading VAE weights specified in settings: F:\webui\webui\stable-diffusion-webui\models\VAE\vae-ft-mse-840000-ema-pruned.safetensors
Applying attention optimization: sdp... done.
Model loaded in 2.9s (create model: 0.6s, apply weights to model: 1.3s, load VAE: 0.8s)
~~~

### original Weight sum
~~~
  model A       : Basil_mix_fixed
  model B       : Anything_v3Fixed-prunedFp16
  model C       : Basil_mix_fixed
  alpha,beta    : (0.5, 0.25)
  weights_alpha :
  weights_beta  :
  mode          : Weight sum
  MBW           : False
  CalcMode      : normal
  Elemental     :
  Weights Seed  : 4216254361.0
  Adjust        :
Loading weights [Anything_v3Fixed-prunedFp16] from cache
Loading weights [Basil_mix_fixed] from cache
Stage 1/2: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1131/1131 [00:20<00:00, 54.22it/s]
Stage 2/2: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1131/1131 [00:00<00:00, 1131351.73it/s]
Saving...
Done!
Creating model from config: F:\webui\webui\stable-diffusion-webui\configs\v1-inference.yaml
Loading VAE weights specified in settings: F:\webui\webui\stable-diffusion-webui\models\VAE\vae-ft-mse-840000-ema-pruned.safetensors
Applying attention optimization: sdp... done.
Model loaded in 3.7s (create model: 0.6s, apply weights to model: 1.2s, load VAE: 0.7s, load textual inversion embeddings: 0.9s, calculate empty prompt: 0.3s).
Python 3.10.11 (tags/v3.10.11:7d4cc5a, Apr  5 2023, 00:38:17) [MSC v.1929 64 bit (AMD64)]
~~~