### PR TITLE
#290

### DIFF
--- a/scripts/mergers/mergers.py
+++ b/scripts/mergers/mergers.py
@@ -210,8 +210,12 @@ def smerge(weights_a,weights_b,model_a,model_b,model_c,base_alpha,base_beta,mode
     
     debug = "debug" in save_sets
     uselerp = "use old calc method" not in save_sets
-    device = "cuda" if "use cuda" in save_sets else "cpu"
 
+    device = "cpu"
+    if "use cuda" in save_sets:
+        if "smoothAdd" in calcmode: print(f"{bcolors.WARNING}Can't use CUDA for {calcmode}, using CPU instead.{bcolors.ENDC}")
+        else: device = "cuda" 
+        
     unload_model_weights(sd_models.model_data.sd_model)
 
     # for from file
@@ -301,6 +305,7 @@ def smerge(weights_a,weights_b,model_a,model_b,model_c,base_alpha,base_beta,mode
     isxl = "conditioner.embedders.1.model.transformer.resblocks.9.mlp.c_proj.weight" in theta_1.keys()
 
     #adjust
+    fine_for_metadata = fine
     if fine.rstrip(",0") != "":
         fine = fineman(fine,isxl)
     else:
@@ -564,6 +569,7 @@ def smerge(weights_a,weights_b,model_a,model_b,model_c,base_alpha,base_beta,mode
             "mbw": useblocks,
             "elemental_merge": deep,
             "calcmode" : calcmode,
+            "adjust" : fine_for_metadata,
             f"{inex}":ex_blocks + ex_elems
             }
         metadata["sd_merge_recipe"] = json.dumps(merge_recipe)

--- a/scripts/mergers/pluslora.py
+++ b/scripts/mergers/pluslora.py
@@ -234,9 +234,7 @@ def on_ui_tabs():
             return f":{ratio},".join(names)+f":{ratio} "
           
         def filterloras(filterstr,dims):
-            print(dims)
-            print(llist.items())
-            filteredloras = [f"{x[0]}({x[1]})" for x in llist.items() if (str(x[1]) in dims or not dims) and filterstr in x[0]]
+            filteredloras = [f"{x[0]}({x[1]})" for x in llist.items() if (str(x[1]) in dims or not dims) and filterstr.lower() in x[0].lower()]
             global selectable
             selectable = filteredloras.copy()
             return gr.update(choices = filteredloras)

--- a/scripts/supermerger.py
+++ b/scripts/supermerger.py
@@ -951,8 +951,12 @@ def get_xyzpreset_data():
     try:
         with open(xyzpath, 'r') as file:
             return json.load(file)
-    except FileNotFoundError:
-        with open(xyzpath, 'w') as file:
+    except FileNotFoundError: pass
+    except json.JSONDecodeError as error:
+        shutil.copyfile(xyzpath, os.path.join(path_root,"broken_xyzpresets.json"))
+        print(error)
+    finally:
+        with open(xyzpath, 'w') as file: 
             json.dump({}, file, indent=4)
         return {}
     
@@ -1072,7 +1076,7 @@ def loadkeys(model_a, lora):
 
 def loadmodel(model):
     checkpoint_info = sd_models.get_closet_checkpoint_match(model)
-    sd = sd_models.read_state_dict(checkpoint_info.filename,"cpu")
+    sd = sd_models.read_state_dict(checkpoint_info.filename,map_location="cpu")
     return sd
 
 ADDRAND = "\n\

--- a/scripts/supermerger.py
+++ b/scripts/supermerger.py
@@ -406,9 +406,16 @@ def on_ui_tabs():
                 with gr.Column(variant="compact"):
                     components.currentmodel = gr.Textbox(label="Current Model",lines=1,value="")
                     components.submit_result = gr.Textbox(label="Message")
-                    mgallery, mgeninfo, mhtmlinfo, mhtmllog = create_output_panel("txt2img", opts.outdir_txt2img_samples)
-
-        # main ui end 
+                    try:
+                        output_panel = create_output_panel("txt2img", opts.outdir_txt2img_samples)
+                        mgallery = output_panel.gallery
+                        mgeninfo = output_panel.generation_info
+                        mhtmlinfo = output_panel.infotext
+                        mhtmllog = output_panel.html_log
+                    except: #for compatibility with the old system
+                        mgallery, mgeninfo, mhtmlinfo, mhtmllog = create_output_panel("txt2img", opts.outdir_txt2img_samples)
+                        
+        # main ui end
     
         with gr.Tab("LoRA", elem_id="tab_lora"):
             pluslora.on_ui_tabs()
@@ -952,12 +959,11 @@ def get_xyzpreset_data():
         with open(xyzpath, 'r') as file:
             return json.load(file)
     except FileNotFoundError: pass
-    except json.JSONDecodeError as error:
+    except json.JSONDecodeError:
         shutil.copyfile(xyzpath, os.path.join(path_root,"broken_xyzpresets.json"))
-        print(error)
     finally:
         with open(xyzpath, 'w') as file: 
-            json.dump({}, file, indent=4)
+            json.dump(dict(), file, indent=4)
         return {}
     
 def get_xyzpreset_keylist():

--- a/scripts/supermerger.py
+++ b/scripts/supermerger.py
@@ -100,15 +100,13 @@ def on_ui_tabs():
 
                     with gr.Row(variant="compact"):
                         model_a = gr.Dropdown(sd_models.checkpoint_tiles(),elem_id="model_converter_model_name",label="Model A",interactive=True)
-                        create_refresh_button(model_a, sd_models.list_models,lambda: {"choices": sd_models.checkpoint_tiles()},"refresh_checkpoint_Z")
                         swap_models_AB = gr.Button(value='⇆', elem_classes=["tool"])
 
                         model_b = gr.Dropdown(sd_models.checkpoint_tiles(),elem_id="model_converter_model_name",label="Model B",interactive=True)
-                        create_refresh_button(model_b, sd_models.list_models,lambda: {"choices": sd_models.checkpoint_tiles()},"refresh_checkpoint_Z")
                         swap_models_BC = gr.Button(value='⇆', elem_classes=["tool"])
 
                         model_c = gr.Dropdown(sd_models.checkpoint_tiles(),elem_id="model_converter_model_name",label="Model C",interactive=True)
-                        create_refresh_button(model_c, sd_models.list_models,lambda: {"choices": sd_models.checkpoint_tiles()},"refresh_checkpoint_Z")
+                        create_refresh_button([model_a,model_b,model_c], sd_models.list_models,lambda: {"choices": sd_models.checkpoint_tiles()},"refresh_checkpoint_Z")
 
                     mode = gr.Radio(label = "Merge Mode",choices = ["Weight sum", "Add difference", "Triple sum", "sum Twice"], value="Weight sum", info="A*(1-alpha)+B*alpha")
                     calcmode = gr.Radio(label = "Calculation Mode",choices = CALCMODES, value = "normal") 

--- a/scripts/supermerger.py
+++ b/scripts/supermerger.py
@@ -674,16 +674,14 @@ def on_ui_tabs():
             return gr.update()
 
         def finetune_reader(finetune):
-            tmp = [t.strip() for t in finetune.split(",")]
-            ret = [gr.update()]*7
-            for i, f in enumerate(tmp[0:7]):
-                try:
-                    f = float(f)
-                    ret[i] = gr.update(value=f)
-                except:
-                    pass
-            return ret
-
+            try:
+                tmp = [float(t) for t in finetune.split(",") if t]
+                assert len(tmp) == 8, f"expected 8 values, received {len(tmp)}."
+            except ValueError as err: gr.Warning(str(err))
+            except AssertionError as err: gr.Warning(str(err))
+            else: return [gr.update(value=x) for x in tmp]
+            return [gr.update()]*8
+        
         # update finetune
         finetunes = [detail1, detail2, detail3, contrast, bri, col1, col2, col3]
         finetune_reset.click(fn=lambda: [gr.update(value="")]+[gr.update(value=0.0)]*8, inputs=[], outputs=[finetune, *finetunes])

--- a/scripts/supermerger.py
+++ b/scripts/supermerger.py
@@ -101,9 +101,11 @@ def on_ui_tabs():
                     with gr.Row(variant="compact"):
                         model_a = gr.Dropdown(sd_models.checkpoint_tiles(),elem_id="model_converter_model_name",label="Model A",interactive=True)
                         create_refresh_button(model_a, sd_models.list_models,lambda: {"choices": sd_models.checkpoint_tiles()},"refresh_checkpoint_Z")
+                        swap_models_AB = gr.Button(value='⇆', elem_classes=["tool"])
 
                         model_b = gr.Dropdown(sd_models.checkpoint_tiles(),elem_id="model_converter_model_name",label="Model B",interactive=True)
                         create_refresh_button(model_b, sd_models.list_models,lambda: {"choices": sd_models.checkpoint_tiles()},"refresh_checkpoint_Z")
+                        swap_models_BC = gr.Button(value='⇆', elem_classes=["tool"])
 
                         model_c = gr.Dropdown(sd_models.checkpoint_tiles(),elem_id="model_converter_model_name",label="Model C",interactive=True)
                         create_refresh_button(model_c, sd_models.list_models,lambda: {"choices": sd_models.checkpoint_tiles()},"refresh_checkpoint_Z")
@@ -806,6 +808,9 @@ def on_ui_tabs():
         deletexyzpreset_b.click(fn=deletexyzpreset_f,inputs=[xyzpresets],outputs=[xyzpresets])
         refreshxyzpresets_b.click(fn=refreshxyzpresets_f,outputs=[xyzpresets])
 
+        swap_models_AB.click(fn=swapvalues,inputs=[model_a,model_b],outputs=[model_a,model_b])
+        swap_models_BC.click(fn=swapvalues,inputs=[model_b,model_c],outputs=[model_b,model_c])
+
     return (supermergerui, "SuperMerger", "supermerger"),
 
 msearch = []
@@ -869,6 +874,8 @@ def searchhistory(words,searchmode):
 
     if outs == []:return [["no result","",""],]
     return outs
+
+def swapvalues(x,y): return gr.update(value=y), gr.update(value=x)
 
 #msettings=[0 weights_a,1 weights_b,2 model_a,3 model_b,4 model_c,5 base_alpha,6 base_beta,7 mode,8 useblocks,9 custom_name,10 save_sets,11 id_sets,12 wpresets]
 #13  deep,14 calcmode,15 luckseed 16:opt_value 17 include/exclude 18: exclude_blocks, 19: exclude_elements

--- a/scripts/supermerger.py
+++ b/scripts/supermerger.py
@@ -121,10 +121,11 @@ def on_ui_tabs():
 
                     with gr.Accordion("Options", open=False):
                         with gr.Row(variant="compact"):
-                            save_sets = gr.CheckboxGroup(["use cuda","save model", "overwrite","safetensors","fp16","save metadata","copy config","prune","Reset CLIP ids","use old calc method","debug"], value=["safetensors"], show_label=False, label="save settings")
+                            save_sets = gr.CheckboxGroup(["use cuda","save model", "overwrite","safetensors","fp16","save metadata","save config","prune","Reset CLIP ids","use old calc method","debug"], value=["safetensors"], show_label=False, label="save settings")
                         with gr.Row():
-                            components.id_sets = gr.CheckboxGroup(["image", "PNG info"], label="save merged model ID to")
-                            opt_value = gr.Slider(label="option(gamma) ", minimum=-1.0, maximum=20, step=0.1, value=0.3, interactive=True)
+                            components.id_sets = gr.CheckboxGroup(["image", "PNG info"], label="save merged model ID to",scale=1)
+                            config_source = gr.Radio(["Any", "A", "B", "C"],value="Any",type='index',label='use config from model:',scale=1)
+                            opt_value = gr.Slider(label="option(gamma) ", minimum=-1.0, maximum=20, step=0.1, value=0.3, interactive=True,scale=2)
                         with gr.Row(variant="compact"):
                             with gr.Column(min_width = 50):
                                 with gr.Row():
@@ -500,7 +501,7 @@ def on_ui_tabs():
         load_history.click(fn=load_historyf,inputs=[history,count],outputs=[history])
         reload_history.click(fn=load_historyf,inputs=[history,count,components.dtrue],outputs=[history])
 
-        components.msettings=[weights_a,weights_b,model_a,model_b,model_c,base_alpha,base_beta,mode,calcmode,useblocks,custom_name,save_sets,components.id_sets,wpresets,deep,finetune,bake_in_vae,opt_value,inex,ex_blocks,ex_elems]
+        components.msettings=[weights_a,weights_b,model_a,model_b,model_c,base_alpha,base_beta,mode,calcmode,useblocks,custom_name,save_sets,components.id_sets,wpresets,deep,finetune,bake_in_vae,opt_value,inex,ex_blocks,ex_elems,config_source]
         components.imagegal = [mgallery,mgeninfo,mhtmlinfo,mhtmllog]
         components.xysettings=[x_type,xgrid,y_type,ygrid,z_type,zgrid,esettings]
         components.genparams=[prompt,neg_prompt,steps,sampler,cfg,seed,width,height,batch_size]

--- a/scripts/supermerger.py
+++ b/scripts/supermerger.py
@@ -100,13 +100,15 @@ def on_ui_tabs():
 
                     with gr.Row(variant="compact"):
                         model_a = gr.Dropdown(sd_models.checkpoint_tiles(),elem_id="model_converter_model_name",label="Model A",interactive=True)
+                        create_refresh_button(model_a, sd_models.list_models,lambda: {"choices": sd_models.checkpoint_tiles()},"refresh_checkpoint_Z")
                         swap_models_AB = gr.Button(value='⇆', elem_classes=["tool"])
 
                         model_b = gr.Dropdown(sd_models.checkpoint_tiles(),elem_id="model_converter_model_name",label="Model B",interactive=True)
+                        create_refresh_button(model_b, sd_models.list_models,lambda: {"choices": sd_models.checkpoint_tiles()},"refresh_checkpoint_Z")
                         swap_models_BC = gr.Button(value='⇆', elem_classes=["tool"])
 
                         model_c = gr.Dropdown(sd_models.checkpoint_tiles(),elem_id="model_converter_model_name",label="Model C",interactive=True)
-                        create_refresh_button([model_a,model_b,model_c], sd_models.list_models,lambda: {"choices": sd_models.checkpoint_tiles()},"refresh_checkpoint_Z")
+                        create_refresh_button(model_c, sd_models.list_models,lambda: {"choices": sd_models.checkpoint_tiles()},"refresh_checkpoint_Z")
 
                     mode = gr.Radio(label = "Merge Mode",choices = ["Weight sum", "Add difference", "Triple sum", "sum Twice"], value="Weight sum", info="A*(1-alpha)+B*alpha")
                     calcmode = gr.Radio(label = "Calculation Mode",choices = CALCMODES, value = "normal") 


### PR DESCRIPTION
Added config selection. Can now use config from any input model when loading a model. 

Also fixed inpaint merging.

There's one issue I ran in to though and I'm not sure if my fix is proper. Trying to save current merge occasionally gets me one of these errors when it tries to load the model at the end of save_model:
```
Traceback (most recent call last):
  File "C:\Users\user\Desktop\stable-diffusion-webui\venv\lib\site-packages\gradio\routes.py", line 488, in run_predict
    output = await app.get_blocks().process_api(
  File "C:\Users\user\Desktop\stable-diffusion-webui\venv\lib\site-packages\gradio\blocks.py", line 1431, in process_api
    result = await self.call_function(
  File "C:\Users\user\Desktop\stable-diffusion-webui\venv\lib\site-packages\gradio\blocks.py", line 1103, in call_function
    prediction = await anyio.to_thread.run_sync(
  File "C:\Users\user\Desktop\stable-diffusion-webui\venv\lib\site-packages\anyio\to_thread.py", line 33, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "C:\Users\user\Desktop\stable-diffusion-webui\venv\lib\site-packages\anyio\_backends\_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
  File "C:\Users\user\Desktop\stable-diffusion-webui\venv\lib\site-packages\anyio\_backends\_asyncio.py", line 807, in run
    result = context.run(func, *args)
  File "C:\Users\user\Desktop\stable-diffusion-webui\venv\lib\site-packages\gradio\utils.py", line 707, in wrapper
    response = f(*args, **kwargs)
  File "C:\Users\user\Desktop\stable-diffusion-webui\extensions\sd-webui-supermerger\scripts\supermerger.py", line 564, in save_current_merge
    msg = savemodel(None,None,custom_name,save_settings)
  File "C:\Users\user\Desktop\stable-diffusion-webui\extensions\sd-webui-supermerger\scripts\mergers\model_util.py", line 150, in savemodel
    load_model(checkpoint_info, already_loaded_state_dict=state_dict)
  File "C:\Users\user\Desktop\stable-diffusion-webui\modules\sd_models.py", line 649, in load_model
    sd_model.cond_stage_model_empty_prompt = get_empty_cond(sd_model)
  File "C:\Users\user\Desktop\stable-diffusion-webui\modules\sd_models.py", line 537, in get_empty_cond
    return sd_model.cond_stage_model([""])
  File "C:\Users\user\Desktop\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "C:\Users\user\Desktop\stable-diffusion-webui\modules\sd_hijack_clip.py", line 234, in forward
    z = self.process_tokens(tokens, multipliers)
  File "C:\Users\user\Desktop\stable-diffusion-webui\modules\sd_hijack_clip.py", line 273, in process_tokens
    z = self.encode_with_transformers(tokens)
  File "C:\Users\user\Desktop\stable-diffusion-webui\modules\sd_hijack_clip.py", line 326, in encode_with_transformers
    outputs = self.wrapped.transformer(input_ids=tokens, output_hidden_states=-opts.CLIP_stop_at_last_layers)
  File "C:\Users\user\Desktop\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py", line 1527, in _call_impl
    result = hook(self, args)
  File "C:\Users\user\Desktop\stable-diffusion-webui\modules\lowvram.py", line 52, in send_me_to_gpu
    module_in_gpu.to(cpu)
  File "C:\Users\user\Desktop\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py", line 1145, in to
    return self._apply(convert)
  File "C:\Users\user\Desktop\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py", line 797, in _apply
    module._apply(fn)
  File "C:\Users\user\Desktop\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py", line 797, in _apply
    module._apply(fn)
  File "C:\Users\user\Desktop\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py", line 797, in _apply
    module._apply(fn)
  [Previous line repeated 2 more times]
  File "C:\Users\user\Desktop\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py", line 820, in _apply
    param_applied = fn(param)
  File "C:\Users\user\Desktop\stable-diffusion-webui\venv\lib\site-packages\torch\nn\modules\module.py", line 1143, in convert
    return t.to(device, dtype if t.is_floating_point() or t.is_complex() else None, non_blocking)
NotImplementedError: Cannot copy out of meta tensor; no data!
```
This error also happens on main, I don't think its introduced by my code. 

My solution was to add this before load_model in savemodel:
```
name = os.path.basename(fname)
checkpoint_info = sd_models.get_closet_checkpoint_match(name)
sd_models.model_data.__init__()
load_model(checkpoint_info, already_loaded_state_dict=state_dict)
```
It works but it was just luck since I don't understand the inner working of webui. I saw that sd_models.model_data.__init__() was used before loading everywhere else in the code. And I figured that changing the model info to that of the saved model might help prevent issues since its a real checkpoint now.

Is this a stupid solution? It seems to work all the time but I might be completely missing something. And I honestly don't understand why the model is loaded there.
