### PR TITLE
Try theta_2 cuda upload to use Triple sum

### DIFF
--- a/scripts/mergers/mergers.py
+++ b/scripts/mergers/mergers.py
@@ -419,8 +419,8 @@ def smerge(weights_a,weights_b,model_a,model_b,model_c,base_alpha,base_beta,mode
         theta_1[key] = theta_1[key].to("cuda")
         try:
             theta_2[key] = theta_2[key].to("cuda")
-        except NameError:
-            None
+        except Exception as e:
+            pass # Do nothing
 
         weight_index = -1
         current_alpha = alpha


### PR DESCRIPTION
The following errors may occur when using the "Triple sum" function.

```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

The problem is, 
* theta_0 and theta_1 were uploaded to CUDA with the code below
* but theta_2 was not uploaded.
code in "mergers.py", 418 line
```python
        theta_0[key] = theta_0[key].to("cuda")
        theta_1[key] = theta_1[key].to("cuda")
```

To solve this, I add simple check code for theta_2
```python
        theta_0[key] = theta_0[key].to("cuda")
        theta_1[key] = theta_1[key].to("cuda")
        try:
            theta_2[key] = theta_2[key].to("cuda")
        except NameError:
            None
```

This method increases GPU memory usage by putting theta_2 on the GPU, but it succeeds if the GPU memory capacity is sufficient.

In my testing, I can do Triplesum on an RTX3080Ti with 12GB of VRAM. But the memory usage is pretty close.

Please review my commit and I hope it will help you.

Added: Fix exception handling

Updated the exception handling from except NameError to the more general except Exception to handle 2 model merge
```Python
        except NameError:
            None
```
to
```python
        except Exception as e:
            pass # Do nothing
```