### PR TITLE
PlusLora Merging error + Networks

### DIFF
--- a/scripts/A1111/networks.py
+++ b/scripts/A1111/networks.py
@@ -346,6 +346,7 @@ def load_networks(names, te_multipliers=None, unet_multipliers=None, dyn_dims=No
 
         net.te_multiplier = te_multipliers[i] if te_multipliers else 1.0
         net.unet_multiplier = unet_multipliers[i] if unet_multipliers else 1.0
+        print(f"dyn_dims = {dyn_dims}")
         net.dyn_dim = dyn_dims[i] if dyn_dims else 1.0
         loaded_networks.append(net)
 

--- a/scripts/mergers/pluslora.py
+++ b/scripts/mergers/pluslora.py
@@ -851,7 +851,7 @@ def pluslora(lnames,loraratios,settings,output,model,save_precision,calc_precisi
     return result + add
 
 def newpluslora(theta_0,filenames,lweis,names, isxl,isv2, keychanger):
-    nets.load_networks(names, [1]* len(names),[1]* len(names), isxl, isv2)
+    nets.load_networks(names, [1]* len(names),[1]* len(names), [1]* len(names), isxl, isv2)
 
     for l, loaded in enumerate(nets.loaded_networks):
         for n, name in enumerate(names):


### PR DESCRIPTION
My original errors was this:
Traceback (most recent call last):
File "/workspace/venv/lib/python3.10/site-packages/gradio/routes.py", line 488, in run_predict
output = await app.get_blocks().process_api(
File "/workspace/venv/lib/python3.10/site-packages/gradio/blocks.py", line 1431, in process_api
result = await self.call_function(
File "/workspace/venv/lib/python3.10/site-packages/gradio/blocks.py", line 1103, in call_function
prediction = await anyio.to_thread.run_sync(
File "/workspace/venv/lib/python3.10/site-packages/anyio/to_thread.py", line 33, in run_sync
return await get_asynclib().run_sync_in_worker_thread(
File "/workspace/venv/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 877, in run_sync_in_worker_thread
return await future
File "/workspace/venv/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 807, in run
result = context.run(func, *args)
File "/workspace/venv/lib/python3.10/site-packages/gradio/utils.py", line 707, in wrapper
response = f(*args, kwargs)
File "/workspace/stable-diffusion-webui/extensions/sd-webui-supermerger/scripts/mergers/pluslora.py", line 777, in pluslora
theta_0 = newpluslora(theta_0,filenames,lweis,names, isxl,isv2, keychanger)
File "/workspace/stable-diffusion-webui/extensions/sd-webui-supermerger/scripts/mergers/pluslora.py", line 854, in newpluslora
nets.load_networks(names, [1] len(names),[1] len(names), isxl, isv2)
File "/workspace/stable-diffusion-webui/extensions/sd-webui-supermerger/scripts/A1111/networks.py", line 349, in load_networks
net.dyn_dim = dyn_dims[i] if dyn_dims else 1.0
TypeError: 'bool' object is not subscriptable

I used gemini to fix a couple things.