### PR TITLE
Check for forge as case insensitive to pick up reforge as well

### DIFF
--- a/scripts/A1111/network_lora.py
+++ b/scripts/A1111/network_lora.py
@@ -5,7 +5,7 @@ import scripts.A1111.network as network
 from modules import devices
 from modules.ui import versions_html
 
-forge = "forge" in versions_html()
+forge = "forge" in versions_html().lower()
 class QkvLinear(torch.nn.Linear):
     pass
 


### PR DESCRIPTION
Current forge check is case sensitive so it doesn't pick up 'reForge'
Added `.lower()` to make this case-insensitive so it properly detects `reForge`