### PR TITLE
Forge neo compat

### DIFF
--- a/install.py
+++ b/install.py
@@ -43,7 +43,7 @@ requirements = [
 # requirements check to reinstall 0.37.1 immediately afterwards. Nothing SuperMerger
 # does needs the older version, so just require diffusers to be present.
 try:
-    if launch.git_tag() == "neo":
+    if launch.git_tag().split(" ", 1)[0] == "neo":
         requirements.append("diffusers")
     else:
         requirements.append("diffusers==0.31.0")

--- a/install.py
+++ b/install.py
@@ -34,10 +34,21 @@ def is_installed(pip_package):
         return False
     
 requirements = [
-"diffusers==0.31.0",
 "scikit-learn",
 "accelerate"
 ]
+
+# Forge Neo pins diffusers==0.37.1 in its own requirements.txt. SuperMerger used to
+# pin ==0.31.0 here, which downgraded it on every launch only for Neo's post-extension
+# requirements check to reinstall 0.37.1 immediately afterwards. Nothing SuperMerger
+# does needs the older version, so just require diffusers to be present.
+try:
+    if launch.git_tag() == "neo":
+        requirements.append("diffusers")
+    else:
+        requirements.append("diffusers==0.31.0")
+except Exception:
+    requirements.append("diffusers==0.31.0")
 
 for module in requirements:
     if not is_installed(module):

--- a/scripts/A1111/lora_patches.py
+++ b/scripts/A1111/lora_patches.py
@@ -1,6 +1,6 @@
 import torch
 
-import networks
+import scripts.A1111.networks as networks
 from modules import patches
 
 

--- a/scripts/A1111/networks.py
+++ b/scripts/A1111/networks.py
@@ -18,7 +18,11 @@ import scripts.A1111.network_oft as network_oft
 import torch
 from typing import Union
 
-from modules import shared, devices, sd_models, errors, scripts, sd_hijack, launch_utils
+from modules import shared, devices, sd_models, errors, scripts, launch_utils
+try:
+    from modules import sd_hijack
+except ImportError:  # Forge Neo has no sd_hijack
+    sd_hijack = None
 import modules.textual_inversion.textual_inversion as textual_inversion
 
 class QkvLinear(torch.nn.Linear):
@@ -384,7 +388,8 @@ def load_networks(names, te_multipliers=None, unet_multipliers=None, dyn_dims=No
 
     if failed_to_load_networks:
         lora_not_found_message = f'Lora not found: {", ".join(failed_to_load_networks)}'
-        sd_hijack.model_hijack.comments.append(lora_not_found_message)
+        if sd_hijack is not None:
+            sd_hijack.model_hijack.comments.append(lora_not_found_message)
         if shared.opts.lora_not_found_warning_console:
             print(f'\n{lora_not_found_message}\n')
         if shared.opts.lora_not_found_gradio_warning:

--- a/scripts/mergers/mergers.py
+++ b/scripts/mergers/mergers.py
@@ -27,7 +27,10 @@ from modules.ui import  plaintext_to_html
 from modules.shared import opts, cmd_opts
 from modules.sd_models import unload_model_weights
 from modules.processing import create_infotext,Processed
-from modules.generation_parameters_copypaste import create_override_settings_dict
+try:
+    from modules.generation_parameters_copypaste import create_override_settings_dict
+except ModuleNotFoundError:  # Forge Neo renamed the module
+    from modules.infotext_utils import create_override_settings_dict
 from scripts.mergers.model_util import filenamecutter,savemodel
 from math import ceil
 import sys
@@ -1277,10 +1280,16 @@ def simggen(s_prompt,s_nprompt,s_steps,s_sampler,s_cfg,s_seed,s_w,s_h,s_batch_si
     # 'Hires checkpoint', 'Hires sampling method', 'Hires prompt', 'Hires negative prompt', 'Override settings', 'Script', 'Refiner', 
     # 'Checkpoint', 'Switch at', 'Seed', 'Extra', 'Variation seed', 'Variation strength', 'Resize seed from width', 'Resize seed from height', '', 'Active', 'Active', 'X Types', 'X Values', 'Y Types', 'Y Values']  
 
+    lowernames = [x.lower() if isinstance(x, str) else x for x in paramsnames]
+
     def g(wanted,wantedv=None):
-        if wanted in paramsnames:return txt2imgparams[paramsnames.index(wanted)]
-        elif wantedv and wantedv in paramsnames:return txt2imgparams[paramsnames.index(wantedv)]
-        else:return None
+        # Forge Neo renamed several labels (case changes, e.g. "Hires checkpoint"
+        # -> "Hires Checkpoint"), so fall back to a case-insensitive lookup
+        for target in (wanted, wantedv):
+            if not target: continue
+            if target in paramsnames: return txt2imgparams[paramsnames.index(target)]
+            if target.lower() in lowernames: return txt2imgparams[lowernames.index(target.lower())]
+        return None
 
     sampler_index = g("Sampling method","Sampling Method")
     if type(sampler_index) is str:
@@ -1329,8 +1338,19 @@ def simggen(s_prompt,s_nprompt,s_steps,s_sampler,s_cfg,s_seed,s_w,s_h,s_batch_si
         do_not_reload_embeddings=True,
     )
     p.hr_checkpoint_name=None if g("Hires checkpoint") == 'Use same checkpoint' else g("Hires checkpoint")
+    if neo:
+        # Neo splits guidance into CFG + distilled CFG (Flux/SD3/Qwen "shift")
+        for _attr, _label in (("distilled_cfg_scale", "Distilled CFG Scale"),
+                              ("hr_cfg", "Hires CFG Scale"),
+                              ("hr_distilled_cfg", "Hires Distilled CFG Scale")):
+            _v = g(_label)
+            if _v is not None: setattr(p, _attr, _v)
+        _hr_sched = g("Hires schedule type")
+        p.hr_scheduler = None if _hr_sched in (None, "Use same scheduler") else _hr_sched
+        _hr_mods = g("Hires VAE / Text Encoder")
+        _hr_mods = [] if _hr_mods in (None, ["Use same choices"]) else _hr_mods
     p.hr_sampler_name=None if hr_sampler_name == 'Use same sampler' else  hr_sampler_name
-    p.hr_additional_modules = []
+    p.hr_additional_modules = _hr_mods if neo else []
 
     if s_sampler is None: s_sampler = 0
 
@@ -1706,8 +1726,10 @@ def model_loader(checkpoint_info, state_dict,metadata, currentmodel):
     if ui_version >= 150: checkpoint_info = fake_checkpoint_info(checkpoint_info,metadata,currentmodel)
 
     if neo:
-        sd_models.model_data.__init__()
-        load_forge_model(state_dict,checkpoint_info)
+        # do NOT re-init model_data here: it would wipe forge_loading_parameters
+        # (additional_modules / unet_storage_dtype) that load_forge_model reads back
+        memory_management.free_memory(1e30, torch.device("cpu"))
+        load_forge_model(state_dict, checkpoint_info)
     elif not forge:
         sd_models.model_data.__init__()
         sd_models.load_model(checkpoint_info, already_loaded_state_dict=state_dict)
@@ -1761,9 +1783,15 @@ def load_forge_model(state_dict,checkpoint_info = None):
     additional_state_dicts = fsd.model_data.forge_loading_parameters.get('additional_modules', [])
     timer.record("cache state dict")
 
-    fsd.dynamic_args['forge_unet_storage_dtype'] = fsd.model_data.forge_loading_parameters.get('unet_storage_dtype', None)
-    fsd.dynamic_args['embedding_dir'] = fsd.cmd_opts.embeddings_dir
-    fsd.dynamic_args['emphasis_name'] = opts.emphasis
+    unet_storage_dtype = fsd.model_data.forge_loading_parameters.get('unet_storage_dtype', None)
+    if neo:
+        # Neo's dynamic_args is a class with typed attributes, not a dict
+        fsd.dynamic_args.forge_unet_storage_dtype = unet_storage_dtype
+        fsd.dynamic_args.embedding_dir = fsd.cmd_opts.embeddings_dir
+    else:
+        fsd.dynamic_args['forge_unet_storage_dtype'] = unet_storage_dtype
+        fsd.dynamic_args['embedding_dir'] = fsd.cmd_opts.embeddings_dir
+        fsd.dynamic_args['emphasis_name'] = opts.emphasis
     sd_model = forge_loader(state_dict, additional_state_dicts)
     timer.record("forge model load")
 
@@ -1789,13 +1817,114 @@ def load_forge_model(state_dict,checkpoint_info = None):
     fsd.model_data.forge_loading_parameters = dict(
         checkpoint_info=checkpoint_info,
         additional_modules=shared.opts.forge_additional_modules,
-        unet_storage_dtype=fsd.dynamic_args['forge_unet_storage_dtype']
+        unet_storage_dtype=unet_storage_dtype
     )
 
 COMP_NAME_AND_PREFIX = {"transformer":PREFIX_M, "text_encoder": "clip_l" , "text_encoder2": "t5xxl", "vae": "vae."}
 
+def split_state_dict_neo(sd, additional_state_dicts: list = None):
+    """Forge Neo's backend.loader.split_state_dict() only accepts a file path;
+    SuperMerger holds the merged model in memory, so mirror it over a state dict."""
+    from backend.state_dict import convert_quantization, try_filter_state_dict
+
+    sd, _ = convert_quantization(sd, {})
+    sd = fld.preprocess_state_dict(sd)
+    guess = huggingface_guess.guess(sd)
+
+    if isinstance(additional_state_dicts, list):
+        for asd in additional_state_dicts:
+            _asd, _meta = load_torch_file(asd, return_metadata=True)
+            _asd, _ = convert_quantization(_asd, _meta)
+            sd = fld.replace_state_dict(sd, _asd, guess, asd)
+            del _asd
+
+    guess.clip_target = guess.clip_target(sd)
+    guess.model_type = guess.model_type(sd)
+    guess.ztsnr = "ztsnr" in sd
+
+    sd = guess.process_vae_state_dict(sd)
+
+    state_dict = {
+        guess.unet_target: try_filter_state_dict(sd, guess.unet_key_prefix),
+        guess.vae_target: try_filter_state_dict(sd, guess.vae_key_prefix),
+    }
+
+    sd = guess.process_clip_state_dict(sd)
+
+    for k, v in guess.clip_target.items():
+        state_dict[v] = try_filter_state_dict(sd, [k + "."])
+
+    state_dict["ignore"] = sd
+
+    if "Anima" in guess.huggingface_repo:
+        fld.process_anima(state_dict["transformer"], state_dict["text_encoder"])
+    if "PiD" in guess.huggingface_repo:
+        fld.process_pid(state_dict["transformer"])
+        state_dict["vae"]["_dim"] = guess.unet_config["lq_latent_channels"]
+
+    print(f'StateDict Keys: {({k: len(v) for k, v in state_dict.items()})}')
+
+    del state_dict["ignore"]
+
+    return state_dict, guess
+
+
+@torch.inference_mode()
+def forge_loader_neo(state_dict, additional_state_dicts):
+    import backend.args
+    from diffusers import DiffusionPipeline
+
+    state_dicts, estimated_config = split_state_dict(state_dict, additional_state_dicts)
+    state_dict = None
+    del state_dict
+
+    repo_name: str = estimated_config.huggingface_repo
+
+    backend.args.dynamic_args.reset()
+    backend.args.dynamic_args.nunchaku = getattr(estimated_config, "nunchaku", False)
+    backend.args.dynamic_args.klein = "klein" in repo_name
+    backend.args.dynamic_args.wan = "Wan" in repo_name
+    backend.args.dynamic_args.pid = "PiD" in repo_name
+
+    local_path = os.path.join(fld.HF, repo_name)
+    config: dict = DiffusionPipeline.load_config(local_path)
+
+    huggingface_components = {}
+    for component_name, v in config.items():
+        if isinstance(v, list) and len(v) == 2:
+            lib_name, cls_name = v
+            component_sd = state_dicts.pop(component_name, None)
+            component = fld.load_huggingface_component(estimated_config, component_name, lib_name, cls_name, local_path, component_sd)
+            if component_sd is not None:
+                del component_sd
+            if component is not None:
+                huggingface_components[component_name] = component
+
+    del state_dicts
+
+    PRED_TYPES = {
+        "EPS": "epsilon",
+        "V_PREDICTION": "v_prediction",
+        "FLUX": "const",
+        "FLOW": "const",
+    }
+
+    if "prediction_type" in getattr(huggingface_components.get("scheduler", None), "config", {}):
+        if estimated_config.model_type.name in PRED_TYPES:
+            huggingface_components["scheduler"].config.prediction_type = PRED_TYPES[estimated_config.model_type.name]
+
+    for M in fld.possible_models:
+        if any(type(estimated_config) is x for x in M.matched_guesses):
+            return M(estimated_config=estimated_config, huggingface_components=huggingface_components)
+
+    print('Failed to recognize model type!')
+    return None
+
+
 @torch.inference_mode()
 def forge_loader(state_dict, additional_state_dicts):
+    if neo:
+        return forge_loader_neo(state_dict, additional_state_dicts)
 
     state_dicts, estimated_config = split_state_dict(state_dict, additional_state_dicts)
     state_dict = None
@@ -1824,6 +1953,9 @@ def forge_loader(state_dict, additional_state_dicts):
     return None
 
 def split_state_dict(sd, additional_state_dicts: list = None):
+    if neo:
+        return split_state_dict_neo(sd, additional_state_dicts)
+
     sd = fld.preprocess_state_dict(sd)
     guess = huggingface_guess.guess(sd)
 

--- a/scripts/mergers/mergers.py
+++ b/scripts/mergers/mergers.py
@@ -1655,10 +1655,11 @@ def resetclip(theta):
 ################################################
 ##### cache
 def cachedealer(start):
+    if neo:
+        return
     if start:
         global orig_cache
-        if not neo:
-            orig_cache = shared.opts.sd_checkpoint_cache
+        orig_cache = shared.opts.sd_checkpoint_cache
         shared.opts.sd_checkpoint_cache = 0
     else:
         shared.opts.sd_checkpoint_cache = orig_cache

--- a/scripts/mergers/mergers.py
+++ b/scripts/mergers/mergers.py
@@ -54,7 +54,7 @@ try:
     from modules import launch_utils
     forge = launch_utils.git_tag()[0:2] == "f2"
     reforge = launch_utils.git_tag()[0:2] == "f1" or launch_utils.git_tag() == "classic" 
-    neo = launch_utils.git_tag() == "neo"
+    neo = launch_utils.git_tag().split(" ", 1)[0] == "neo"
 except:
     forge = reforge = neo = False
 

--- a/scripts/mergers/mergers.py
+++ b/scripts/mergers/mergers.py
@@ -338,7 +338,7 @@ def smerge(weights_a,weights_b,model_a,model_b,model_c,base_alpha,base_beta,mode
     qdtypes[1] = qdtyper(theta_1)
     prefixer(theta_1)
     
-    isxl = "conditioner.embedders.1.model.transformer.resblocks.9.mlp.c_proj.weight" in theta_1.keys()
+    isxl = any(k.startswith("conditioner.embedders.1.") for k in theta_1.keys())
     isflux = any("double_block" in k for k in theta_1.keys())
 
     #adjust
@@ -397,6 +397,9 @@ def smerge(weights_a,weights_b,model_a,model_b,model_c,base_alpha,base_beta,mode
     else:
         theta_0 = load_model_weights_m(model_a,1,cachetarget,device).copy()
 
+    if not isxl:
+        isxl = any(k.startswith("conditioner.embedders.1.") for k in theta_0.keys())
+
     qdtypes[0] = qdtyper(theta_0)
     need_revert = prefixer(theta_0)
 
@@ -454,7 +457,7 @@ def smerge(weights_a,weights_b,model_a,model_b,model_c,base_alpha,base_beta,mode
         else:
             continue
         
-        weight_index_xl = BLOCKIDXLLL.index(block)
+        weight_index_xl = BLOCKIDXLLL.index(block) if isxl and block in BLOCKIDXLLL else -1
 
         if useblocks:
             if weight_index > 0:
@@ -634,6 +637,17 @@ def smerge(weights_a,weights_b,model_a,model_b,model_c,base_alpha,base_beta,mode
         theta_2 = None
         del theta_2
     gc.collect()
+
+    ##### Sanity check: repair NaN/Inf produced by the merge (fp16 overflow etc.)
+    bad_keys = []
+    for key, tensor in theta_0.items():
+        if not torch.is_tensor(tensor) or not torch.is_floating_point(tensor):
+            continue
+        if not torch.isfinite(tensor).all():
+            bad_keys.append(key)
+            theta_0[key] = torch.nan_to_num(tensor, nan=0.0, posinf=65504.0, neginf=-65504.0)
+    if bad_keys:
+        print(f"WARNING: merge produced NaN/Inf in {len(bad_keys)} tensor(s), values were clamped/zeroed. First few: {bad_keys[:10]}")
 
     ##### BakeVAE
     bake_in_vae_filename = sd_vae.vae_dict.get(bake_in_vae, None)

--- a/scripts/mergers/model_util.py
+++ b/scripts/mergers/model_util.py
@@ -122,7 +122,7 @@ def savemodel(state_dict,currentmodel,fname,savesets,metadata={}):
         return _err_msg
 
     print("Saving...")
-    isxl = "conditioner.embedders.1.model.transformer.resblocks.9.mlp.c_proj.weight" in state_dict
+    isxl = any(k.startswith("conditioner.embedders.1.") for k in state_dict.keys())
     if isxl:
         # prune share memory tensors, "cond_stage_model." prefixed base tensors are share memory with "conditioner." prefixed tensors
         for key in list(state_dict.keys()):

--- a/scripts/mergers/model_util.py
+++ b/scripts/mergers/model_util.py
@@ -2,7 +2,11 @@ import os
 import torch
 import safetensors.torch
 import threading
-from modules import shared, sd_hijack, sd_models
+from modules import shared, sd_models
+try:
+    from modules import sd_hijack
+except ImportError:  # Forge Neo has no sd_hijack
+    sd_hijack = None
 import json
 
 try:
@@ -55,7 +59,8 @@ def savemodel(state_dict,currentmodel,fname,savesets,metadata={}):
             print("load from shared.sd_model..")
 
             # restore textencoder
-            sd_hijack.model_hijack.undo_hijack(shared.sd_model)
+            if sd_hijack is not None:
+                sd_hijack.model_hijack.undo_hijack(shared.sd_model)
 
             for name,module in shared.sd_model.named_modules():
                 if hasattr(module,"network_weights_backup"):
@@ -67,7 +72,8 @@ def savemodel(state_dict,currentmodel,fname,savesets,metadata={}):
                     other_dict[key] = state_dict[key]
                     del state_dict[key]
 
-            sd_hijack.model_hijack.hijack(shared.sd_model)
+            if sd_hijack is not None:
+                sd_hijack.model_hijack.hijack(shared.sd_model)
         else:
             return "No current loaded model found"
 
@@ -96,7 +102,13 @@ def savemodel(state_dict,currentmodel,fname,savesets,metadata={}):
     else:
         fname = fname if ext in fname else fname +pre+ext
 
-    fname = os.path.join(shared.cmd_opts.ckpt_dir if shared.cmd_opts.ckpt_dir is not None else sd_models.model_path, fname)
+    # Forge Neo replaced --ckpt-dir with the repeatable --ckpt-dirs (a list);
+    # save into the first configured directory, else the default model path
+    ckpt_dir = getattr(shared.cmd_opts, "ckpt_dir", None)
+    if ckpt_dir is None:
+        ckpt_dirs = getattr(shared.cmd_opts, "ckpt_dirs", None) or []
+        ckpt_dir = ckpt_dirs[0] if ckpt_dirs else None
+    fname = os.path.join(ckpt_dir if ckpt_dir is not None else sd_models.model_path, fname)
     fname = fname.replace("ProgramFiles_x86_","Program Files (x86)")
 
     if len(fname) > 255:

--- a/scripts/mergers/pluslora.py
+++ b/scripts/mergers/pluslora.py
@@ -24,7 +24,8 @@ from scripts.mergers.model_util import filenamecutter, savemodel
 from scripts.mergers.mergers import extract_super, unload_forge, q_dequantize, q_quantize, qdtyper, prefixer, BLOCKIDFLUX
 from tqdm import tqdm
 
-forge = launch_utils.git_tag()[0:2] == "f2"
+neo = launch_utils.git_tag() == "neo"
+forge = launch_utils.git_tag()[0:2] == "f2" or neo
 
 selectable = []
 pchanged = False
@@ -870,7 +871,8 @@ def pluslora(lnames,loraratios,settings,output,model,save_precision,calc_precisi
     result = savemodel(theta_0,dname,output,settings)
 
     lora.loaded_loras.clear()
-    sd_models.checkpoints_loaded.clear()
+    if hasattr(sd_models, "checkpoints_loaded"):  # absent on Forge Neo
+        sd_models.checkpoints_loaded.clear()
     if forge:
         from modules.sd_models import FakeInitialModel
         sd_models.unload_model_weights()

--- a/scripts/mergers/pluslora.py
+++ b/scripts/mergers/pluslora.py
@@ -806,7 +806,7 @@ def pluslora(lnames,loraratios,settings,output,model,save_precision,calc_precisi
         qkeys = list(theta_0.keys())
         q_dequantize(theta_0,dtype,device,torch.float16,False)
 
-    isxl = "conditioner.embedders.1.model.transformer.resblocks.9.mlp.c_proj.weight" in theta_0.keys()
+    isxl = any(k.startswith("conditioner.embedders.1.") for k in theta_0.keys())
     isv2 = "cond_stage_model.model.transformer.resblocks.0.attn.out_proj.weight" in theta_0.keys()
     isflux = any("double_block" in k for k in theta_0.keys())
     need_revert = prefixer(theta_0) if isflux else False

--- a/scripts/mergers/pluslora.py
+++ b/scripts/mergers/pluslora.py
@@ -24,7 +24,7 @@ from scripts.mergers.model_util import filenamecutter, savemodel
 from scripts.mergers.mergers import extract_super, unload_forge, q_dequantize, q_quantize, qdtyper, prefixer, BLOCKIDFLUX
 from tqdm import tqdm
 
-neo = launch_utils.git_tag() == "neo"
+neo = launch_utils.git_tag().split(" ", 1)[0] == "neo"
 forge = launch_utils.git_tag()[0:2] == "f2" or neo
 
 selectable = []

--- a/scripts/supermerger.py
+++ b/scripts/supermerger.py
@@ -1210,7 +1210,7 @@ ISXLBLOCK=[True,  True,  True,  True,  True,  True,  True,  True,  True,  True, 
 BLOCKIDS = [BLOCKID,BLOCKIDXL,BLOCKIDXLL,BLOCKIDXLLL]
 
 def modeltype(sd):
-    if "conditioner.embedders.1.model.transformer.resblocks.9.mlp.c_proj.weight" in sd.keys():
+    if any(k.startswith("conditioner.embedders.1.") for k in sd.keys()):
         return "XL"
     elif any("double"in x for x in sd.keys()):
         if any("nf4"in x for x in sd.keys()):return "flux.nf4"


### PR DESCRIPTION
**DONE WITH CLAUDE CODE, BUT VERIFIED WORKING:**

Forge Neo (git_tag "neo") diverged from Forge classic in several APIs
SuperMerger depends on. The existing `neo` branches were not enough for
the extension to load or run there — it failed at import time, so the
tab never appeared.
Two commits, independent:
1. The compatibility work itself.
2. Dropping the diffusers==0.31.0 pin on Neo only. Neo pins 0.37.1 and
   re-checks its requirements after extension installers run, so every
   launch did a downgrade followed immediately by an upgrade. Drop this
   commit if the pin matters for another UI.
Tested on Forge Neo with SDXL: merge, model reload (keeping the selected
VAE / text encoder and low-bits dtype), and save all work. Classic Forge
and A1111 paths are unchanged — every change is behind a `neo` check or
a guarded import.
Less certain: the pluslora.py changes (Extract LoRA, Merge LoRA to
checkpoint). That code was taking the A1111 branch on Neo and calling
sd_models.load_model / read_state_dict, which don't exist there. Fixed by
inspection but not exercised end to end.